### PR TITLE
Disable auto-conversion on infile to prevent double conversion

### DIFF
--- a/git-patches/zostagging/iconv.c.patch
+++ b/git-patches/zostagging/iconv.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/iconv.c b/src/iconv.c
-index ec4caa1..deaebb4 100644
+index ec4caa1..fd7c8e7 100644
 --- a/src/iconv.c
 +++ b/src/iconv.c
 @@ -43,6 +43,10 @@
@@ -82,7 +82,19 @@ index ec4caa1..deaebb4 100644
  {
    char inbuf[4096+4096];
    size_t inbufrest = 0;
-@@ -835,6 +897,18 @@ static int convert (iconv_t cd, int infile, const char* infilename)
+@@ -686,6 +748,11 @@ static int convert (iconv_t cd, int infile, const char* infilename)
+ 
+ #if O_BINARY
+   SET_BINARY(infile);
++#endif
++#ifdef __MVS__
++  // Turn off z/OS auto-conversion
++  struct f_cnvrt req = {SETCVTOFF, 0, 0};
++  fcntl(infile, F_CONTROL_CVT, &req);
+ #endif
+   line = 1; column = 0;
+   iconv(cd,NULL,NULL,NULL,NULL);
+@@ -835,6 +902,18 @@ static int convert (iconv_t cd, int infile, const char* infilename)
      goto done;
    }
   done:
@@ -101,7 +113,7 @@ index ec4caa1..deaebb4 100644
    if (outbuf != initial_outbuf)
      free(outbuf);
    return status;
-@@ -1113,7 +1187,7 @@ int main (int argc, char* argv[])
+@@ -1113,7 +1192,7 @@ int main (int argc, char* argv[])
      if (i == argc)
        status = convert(cd,fileno(stdin),
                         /* TRANSLATORS: A filename substitute denoting standard input.  */
@@ -110,7 +122,7 @@ index ec4caa1..deaebb4 100644
      else {
        status = 0;
        for (; i < argc; i++) {
-@@ -1129,7 +1203,7 @@ int main (int argc, char* argv[])
+@@ -1129,7 +1208,7 @@ int main (int argc, char* argv[])
                  infilename);
            status = 1;
          } else {


### PR DESCRIPTION
* Should resolve this case: https://github.com/ZOSOpenTools/libiconvport/issues/12#issuecomment-1502024193