### PR TITLE
re-organize code to respond to Bruno requests

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -6,7 +6,7 @@ export ZOPEN_GIT_URL="https://git.savannah.gnu.org/git/libiconv.git"
 export ZOPEN_TARBALL_DEPS="make gettext"
 export ZOPEN_GIT_DEPS="make gettext automake autoconf perl m4 gperf sed coreutils diffutils findutils groff"
 export ZOPEN_EXTRA_CONFIGURE_OPTS="--enable-extra-encodings"
-export ZOPEN_CHECK_OPTS='check'
+export ZOPEN_CHECK_OPTS='check -i'
 
 rm -f patches
 if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then

--- a/buildenv
+++ b/buildenv
@@ -24,7 +24,7 @@ zopen_check_results()
   chk="$1/$2_check.log"
 
   totalTests=198
-  testsRun=$(grep '^/bin/sh ./check-' "${chk}" | wc -l)
+  testsRun=$(grep '^/bin/bash ./check-' "${chk}" | wc -l)
   actualFailures=$((totalTests-testsRun))
   echo "totalTests:${totalTests}"
   echo "expectedFailures:1"

--- a/buildenv
+++ b/buildenv
@@ -4,7 +4,7 @@ export ZOPEN_TYPE="GIT"
 export ZOPEN_TARBALL_URL="https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz"
 export ZOPEN_GIT_URL="https://git.savannah.gnu.org/git/libiconv.git"
 export ZOPEN_TARBALL_DEPS="make gettext"
-export ZOPEN_GIT_DEPS="make gettext automake autoconf perl m4 gperf sed coreutils diffutils findutils groff"
+export ZOPEN_GIT_DEPS="make gettext automake autoconf perl m4 gperf sed coreutils diffutils findutils groff bash"
 export ZOPEN_EXTRA_CONFIGURE_OPTS="--enable-extra-encodings"
 export ZOPEN_CHECK_OPTS='check -i'
 

--- a/git-patches/Makefile.devel.patch
+++ b/git-patches/Makefile.devel.patch
@@ -1,13 +1,15 @@
 diff --git a/Makefile.devel b/Makefile.devel
-index 5535acc..0a1ac6a 100644
+index 5535acc..37a25b8 100644
 --- a/Makefile.devel
 +++ b/Makefile.devel
-@@ -9,7 +9,7 @@ AUTOHEADER = autoheader
+@@ -9,8 +9,8 @@ AUTOHEADER = autoheader
  AUTOMAKE = automake-1.16
  ACLOCAL = aclocal-1.16
  GPERF = gperf
 -CC = gcc -Wall
-+CC = xlclang -qascii
- CFLAGS = -O
+-CFLAGS = -O
++CC ?= gcc -Wall
++CFLAGS ?= -O
  MAN2HTML = groff -mandoc -Thtml
  CP = cp
+ RM = rm -f

--- a/git-patches/zostagging/Makefile.in.patch
+++ b/git-patches/zostagging/Makefile.in.patch
@@ -1,22 +1,13 @@
 diff --git a/tests/Makefile.in b/tests/Makefile.in
-index 794a379..c7629b6 100644
+index 794a379..3a3e24f 100644
 --- a/tests/Makefile.in
 +++ b/tests/Makefile.in
-@@ -21,7 +21,7 @@ RM = rm -f
- 
- #### End of system configuration section. ####
- 
--SHELL = @SHELL@
-+SHELL ?= @SHELL@
- 
- # Needed by $(LIBTOOL).
- top_builddir = ..
 @@ -162,6 +162,8 @@ check : all table-from table-to ../src/iconv_no_i18n is-native test-shiftseq tes
  	$(SHELL) $(srcdir)/check-subst
  #	/* EBCDIC specific functionality */
  	$(SHELL) $(srcdir)/check-ebcdic
 +# /* test z/OS file tagging */
-+	$(SHELL) $(srcdir)/check-tag
++	$(SHELL) $(srcdir)/check-tag @host_os@
  #	/* shift sequence before invalid multibyte character */
  	./test-shiftseq
  #	/* conversion to wchar_t */

--- a/git-patches/zostagging/README.md
+++ b/git-patches/zostagging/README.md
@@ -5,3 +5,9 @@ but only on z/OS.
 
 This requires a change to iconv.c and there is a corresponding unit 
 test provided to validate that the tagging is correctly performed.
+
+A new header file zos-tag.h for z/OS specific file tagging code is
+added to keep z/OS specific changes out of the mainline as much as
+possible.
+
+

--- a/git-patches/zostagging/check-tag.patch
+++ b/git-patches/zostagging/check-tag.patch
@@ -1,17 +1,18 @@
 diff --git a/tests/check-tag b/tests/check-tag
 new file mode 100755
-index 0000000..f9fad56
+index 0000000..f593728
 --- /dev/null
 +++ b/tests/check-tag
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,44 @@
 +#!/bin/sh
 +# Check that files on z/OS are properly tagged with their CCSIDs
 +set -e
++host_os="$1"
 +iconv=../src/iconv_no_i18n
 +
 +# This test is only meaningful on z/OS (previously called OS/390)
 +rc=0
-+if uname -s | grep 'OS/390' >/dev/null ; then
++if  [ "${host_os}x" = 'openeditionx' ] ; then
 +
 +  printf 'hello' | $iconv -f ISO8859-1 -t IBM-1047 > tmp-tag-1
 +  if ls -T tmp-tag-1 | grep -v 'IBM-1047' ; then

--- a/git-patches/zostagging/iconv.c.patch
+++ b/git-patches/zostagging/iconv.c.patch
@@ -1,80 +1,21 @@
 diff --git a/src/iconv.c b/src/iconv.c
-index ec4caa1..fd7c8e7 100644
+index ec4caa1..c071ae8 100644
 --- a/src/iconv.c
 +++ b/src/iconv.c
-@@ -43,6 +43,10 @@
+@@ -43,6 +43,11 @@
  #include "uniwidth.h"
  #include "uniwidth/cjk.h"
  
 +#ifdef __MVS__
 +#include <_Ccsid.h>
++#include "zos-tag.h"
 +#endif
 +
  /* Ensure that iconv_no_i18n does not depend on libintl.  */
  #ifdef NO_I18N
  #include <stdarg.h>
-@@ -672,9 +676,67 @@ static void conversion_error_other (int errnum, const char* infilename)
-         infilename,line,column);
- }
+@@ -674,7 +679,7 @@ static void conversion_error_other (int errnum, const char* infilename)
  
-+#ifdef __MVS__
-+/* See: https://www.ibm.com/docs/en/zos/latest?topic=lf-toccsid-convert-codeset-name-coded-character-set-id */
-+
-+static void chgpfx(char* encoding, size_t enclen, size_t pfxlen, const char* normpfx, size_t normpfxlen)
-+{
-+  /* assertion: enclen >= pfxlen >= normpfxlen */
-+  if (normpfxlen > 0) {
-+    memcpy(encoding, normpfx, normpfxlen);
-+  }
-+  memcpy(&encoding[normpfxlen], &encoding[pfxlen], enclen-pfxlen+1);
-+}
-+
-+static __ccsid_t map_encoding_to_ccsid (const char* encoding)
-+{
-+  size_t enclen = strlen(encoding);
-+  char* updtenc = (char*) xmalloc(enclen+1);
-+  memcpy(updtenc, encoding, enclen+1);
-+  
-+  /*
-+   * Some strings are known to gnu iconv but not z/OS __toCcsid. 
-+   * Examples are ISO-8859-1, ISO_8859-2, CP819 (which map to ISO8859-1, ISO8859-2, 819)
-+   *
-+   * The following are supported encodings and corresponding output CCSIDs
-+   *
-+   * CCSID Encoding
-+	 * 819  ISO8859-1
-+	 * 912  ISO8859-2
-+	 * 914  ISO8859-4
-+	 * 915  ISO8859-5
-+	 * 1089 ISO8859-6
-+   * 813  ISO8859-7
-+	 * 916  ISO8859-8
-+	 * 920  ISO8859-9
-+	 * 921  ISO8859-13
-+	 * 923  ISO8859-15
-+   */
-+   #define ISO8859      "ISO8859"
-+   #define ISO8859_LEN (sizeof(ISO8859)-1)
-+   #define ISO8859_DASH "ISO-8859"
-+   #define ISO8859_DASH_LEN (sizeof(ISO8859_DASH)-1)
-+   #define ISO8859_UL "ISO_8859"
-+   #define ISO8859_UL_LEN (sizeof(ISO8859_UL)-1)
-+   #define CP "CP"
-+   #define CP_LEN (sizeof(CP)-1)
-+   #define NO_PFX ""
-+   #define NO_PFX_LEN (0)
-+
-+ if (enclen > ISO8859_DASH_LEN && !memcmp(ISO8859_DASH, encoding, ISO8859_DASH_LEN)) {
-+   chgpfx(updtenc, enclen, ISO8859_DASH_LEN, ISO8859, ISO8859_LEN);
-+ } else if (enclen > ISO8859_UL_LEN && !memcmp(ISO8859_UL, encoding, ISO8859_UL_LEN)) {
-+   chgpfx(updtenc, enclen, ISO8859_UL_LEN, ISO8859, ISO8859_LEN);
-+ } else if (enclen > CP_LEN && !memcmp(CP, encoding, CP_LEN)) {
-+   chgpfx(updtenc, enclen, CP_LEN, NO_PFX, NO_PFX_LEN);
-+ }
-+ return __toCcsid(updtenc);
-+}
-+#endif
-+
  /* Convert the input given in infile.  */
  
 -static int convert (iconv_t cd, int infile, const char* infilename)
@@ -82,38 +23,19 @@ index ec4caa1..fd7c8e7 100644
  {
    char inbuf[4096+4096];
    size_t inbufrest = 0;
-@@ -686,6 +748,11 @@ static int convert (iconv_t cd, int infile, const char* infilename)
- 
- #if O_BINARY
-   SET_BINARY(infile);
-+#endif
-+#ifdef __MVS__
-+  // Turn off z/OS auto-conversion
-+  struct f_cnvrt req = {SETCVTOFF, 0, 0};
-+  fcntl(infile, F_CONTROL_CVT, &req);
- #endif
-   line = 1; column = 0;
-   iconv(cd,NULL,NULL,NULL,NULL);
-@@ -835,6 +902,18 @@ static int convert (iconv_t cd, int infile, const char* infilename)
+@@ -835,6 +840,11 @@ static int convert (iconv_t cd, int infile, const char* infilename)
      goto done;
    }
   done:
 +#ifdef __MVS__
 +  if (!status) {
-+    __ccsid_t newccsid = map_encoding_to_ccsid(tocode);
-+    if (newccsid) {
-+      attrib_t attr = {0};
-+      attr.att_filetagchg = 1;
-+      attr.att_filetag.ft_ccsid = newccsid;
-+      attr.att_filetag.ft_txtflag = 1;
-+      status = __fchattr(fileno(stdout), &attr, sizeof(attr));
-+    }
++    status = tagfile(fileno(stdout), tocode);
 +  }
 +#endif
    if (outbuf != initial_outbuf)
      free(outbuf);
    return status;
-@@ -1113,7 +1192,7 @@ int main (int argc, char* argv[])
+@@ -1113,7 +1123,7 @@ int main (int argc, char* argv[])
      if (i == argc)
        status = convert(cd,fileno(stdin),
                         /* TRANSLATORS: A filename substitute denoting standard input.  */
@@ -122,7 +44,7 @@ index ec4caa1..fd7c8e7 100644
      else {
        status = 0;
        for (; i < argc; i++) {
-@@ -1129,7 +1208,7 @@ int main (int argc, char* argv[])
+@@ -1129,7 +1139,7 @@ int main (int argc, char* argv[])
                  infilename);
            status = 1;
          } else {

--- a/git-patches/zostagging/zos-tag.h.patch
+++ b/git-patches/zostagging/zos-tag.h.patch
@@ -1,0 +1,83 @@
+diff --git a/src/zos-tag.h b/src/zos-tag.h
+new file mode 100644
+index 0000000..58f3b67
+--- /dev/null
++++ b/src/zos-tag.h
+@@ -0,0 +1,77 @@
++#ifndef __ZOS_TAG__
++  #define __ZOS_TAG__ 1
++
++#ifdef __MVS__
++/* See: https://www.ibm.com/docs/en/zos/latest?topic=lf-toccsid-convert-codeset-name-coded-character-set-id */
++
++static void chgpfx(char* encoding, size_t enclen, size_t pfxlen, const char* normpfx, size_t normpfxlen)
++{
++  /* assertion: enclen >= pfxlen >= normpfxlen */
++  if (normpfxlen > 0) {
++    memcpy(encoding, normpfx, normpfxlen);
++  }
++  memcpy(&encoding[normpfxlen], &encoding[pfxlen], enclen-pfxlen+1);
++}
++
++static __ccsid_t map_encoding_to_ccsid (const char* encoding)
++{
++  size_t enclen = strlen(encoding);
++  char* updtenc = (char*) xmalloc(enclen+1);
++  memcpy(updtenc, encoding, enclen+1);
++
++  /*
++   * Some strings are known to gnu iconv but not z/OS __toCcsid.
++   * Examples are ISO-8859-1, ISO_8859-2, CP819 (which map to ISO8859-1, ISO8859-2, 819)
++   *
++   * The following are supported encodings and corresponding output CCSIDs
++   *
++   * CCSID Encoding
++   * 819  ISO8859-1
++   * 912  ISO8859-2
++   * 914  ISO8859-4
++   * 915  ISO8859-5
++   * 1089 ISO8859-6
++   * 813  ISO8859-7
++   * 916  ISO8859-8
++   * 920  ISO8859-9
++   * 921  ISO8859-13
++   * 923  ISO8859-15
++   */
++   #define ISO8859      "ISO8859"
++   #define ISO8859_LEN (sizeof(ISO8859)-1)
++   #define ISO8859_DASH "ISO-8859"
++   #define ISO8859_DASH_LEN (sizeof(ISO8859_DASH)-1)
++   #define ISO8859_UL "ISO_8859"
++   #define ISO8859_UL_LEN (sizeof(ISO8859_UL)-1)
++   #define CP "CP"
++   #define CP_LEN (sizeof(CP)-1)
++   #define NO_PFX ""
++   #define NO_PFX_LEN (0)
++
++ if (enclen > ISO8859_DASH_LEN && !memcmp(ISO8859_DASH, encoding, ISO8859_DASH_LEN)) {
++   chgpfx(updtenc, enclen, ISO8859_DASH_LEN, ISO8859, ISO8859_LEN);
++ } else if (enclen > ISO8859_UL_LEN && !memcmp(ISO8859_UL, encoding, ISO8859_UL_LEN)) {
++   chgpfx(updtenc, enclen, ISO8859_UL_LEN, ISO8859, ISO8859_LEN);
++ } else if (enclen > CP_LEN && !memcmp(CP, encoding, CP_LEN)) {
++   chgpfx(updtenc, enclen, CP_LEN, NO_PFX, NO_PFX_LEN);
++ }
++ return __toCcsid(updtenc);
++}
++
++static int tagfile(int filedes, const char* tocode)
++{
++  int status = 0;
++
++  __ccsid_t newccsid = map_encoding_to_ccsid(tocode);
++  if (newccsid) {
++    attrib_t attr = {0};
++    attr.att_filetagchg = 1;
++    attr.att_filetag.ft_ccsid = newccsid;
++    attr.att_filetag.ft_txtflag = 1;
++    status = __fchattr(filedes, &attr, sizeof(attr));
++  }
++  return status;
++}
++#endif
++#endif
++

--- a/git-patches/zostagging/zos-tag.h.patch
+++ b/git-patches/zostagging/zos-tag.h.patch
@@ -10,7 +10,7 @@ index 0000000..58f3b67
 +#ifdef __MVS__
 +/* See: https://www.ibm.com/docs/en/zos/latest?topic=lf-toccsid-convert-codeset-name-coded-character-set-id */
 +
-+static void chgpfx(char* encoding, size_t enclen, size_t pfxlen, const char* normpfx, size_t normpfxlen)
++static void chgpfx (char* encoding, size_t enclen, size_t pfxlen, const char* normpfx, size_t normpfxlen)
 +{
 +  /* assertion: enclen >= pfxlen >= normpfxlen */
 +  if (normpfxlen > 0) {


### PR DESCRIPTION
Bruno had requested changes:

  - iconv.c.patch: I would refactor the z/OS specific code to a separate file
    zos.h or zos-util.h. Adding the 'tocode' parameter to the 'convert'
    function for all platforms is OK.
  - Makefile.in.patch: The "SHELL ?= ..." patch cannot be added: This Makefile
    needs to stay in POSIX make syntax; GNU make additions are not OK.
    The other part, line 18-19, should use a tab for indentation, as usual in
    Makefiles.
  - check-tag.patch: Looks OK. Just a suggestion: Instead of testing the value
    of 'uname -s', better test the value of @host_os@ that can be passed from
    the Makefile. In GNU, this is the uniform way of getting the canonicalized
    string that designates the operating system. With it, the previous methods
    (arch, uname, etc.) are no longer relevant.

-I created a zos-tag.h (hope that is ok) and moved z/OS code to there
-I removed the SHELL ?= patch
-I changed the code to use @host_os@ and passed the parm in from Makefile.in
