### PR TITLE
Fix testRun calculation

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -24,7 +24,7 @@ zopen_check_results()
   chk="$1/$2_check.log"
 
   totalTests=198
-  testsRun=$(grep '^/bin/bash ./check-' "${chk}" | wc -l)
+  testsRun=$(grep '/bin/bash ./check-' "${chk}" | wc -l)
   actualFailures=$((totalTests-testsRun))
   echo "totalTests:${totalTests}"
   echo "expectedFailures:1"


### PR DESCRIPTION
When we add bash as a dep, it gets picked up by the tests, which may not be in /bin/bash